### PR TITLE
[WIP] Add an ignition config for VMware image builder

### DIFF
--- a/Vagrantfile.builder-flatcar
+++ b/Vagrantfile.builder-flatcar
@@ -1,0 +1,25 @@
+ENV["TERM"] = "xterm-256color"
+ENV["LC_ALL"] = "en_US.UTF-8"
+
+Vagrant.require_version '>= 2.0.4'
+
+Vagrant.configure('2') do |config|
+  config.ssh.username = 'builder'
+  config.ssh.insert_key = false
+  config.ssh.private_key_path = './vagrant-insecure-key'
+  config.vm.box = 'flatcar-' + ENV["FLATCAR_CHANNEL"] + '-' + ENV["FLATCAR_VERSION"]
+  config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh"
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+  config.vm.provider :virtualbox do |v|
+    v.check_guest_additions = false
+    v.functional_vboxsf = false
+    v.cpus = 2
+    v.memory = 3072
+  end
+  config.vm.provider :libvirt do |v|
+    v.cpus = 2
+    v.memory = 3072
+  end
+  config.vm.define 'vagrant-' + ENV["FLATCAR_CHANNEL"] do |c|
+  end
+end

--- a/Vagrantfile.builder-flatcar
+++ b/Vagrantfile.builder-flatcar
@@ -6,7 +6,7 @@ Vagrant.require_version '>= 2.0.4'
 Vagrant.configure('2') do |config|
   config.ssh.username = 'builder'
   config.ssh.insert_key = false
-  config.ssh.private_key_path = './vagrant-insecure-key'
+  config.ssh.private_key_path = ENV["VAGRANT_SSH_PRIVATE_KEY"]
   config.vm.box = 'flatcar-' + ENV["FLATCAR_CHANNEL"] + '-' + ENV["FLATCAR_VERSION"]
   config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh"
   config.vm.synced_folder '.', '/vagrant', disabled: true

--- a/ignition-builder.json
+++ b/ignition-builder.json
@@ -1,0 +1,60 @@
+{
+  "ignition": {
+    "config": {},
+    "security": {
+      "tls": {}
+    },
+    "timeouts": {},
+    "version": "2.2.0"
+  },
+  "networkd": {
+    "units": [
+      {
+        "name": "yy-vmware.network",
+        "dropins": [
+          {
+            "name": "persistent-dhcp.conf",
+            "contents": "[DHCP]\nClientIdentifier=mac"
+          }
+        ]
+      }
+    ]
+  },
+  "passwd": {
+    "users": [
+      {
+        "groups": [
+          "wheel",
+          "sudo",
+          "docker"
+        ],
+        "name": "builder",
+        "passwordHash": "$1$iy0TfVpV$YkL12Rk42daUGy40rvREt1",
+        "sshAuthorizedKeys": [
+          "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key"
+        ]
+      }
+    ]
+  },
+  "storage": {
+    "files": [
+      {
+        "filesystem": "root",
+        "path": "/etc/coreos/update.conf",
+        "contents": {
+          "source": "data:,%0AREBOOT_STRATEGY%3D%22reboot%22",
+          "verification": {}
+        },
+        "mode": 420
+      }
+    ]
+  },
+  "systemd": {
+    "units": [
+      {
+        "enable": true,
+        "name": "docker.service"
+      }
+    ]
+  }
+}

--- a/ignition-builder.json
+++ b/ignition-builder.json
@@ -30,9 +30,7 @@
         ],
         "name": "builder",
         "passwordHash": "$1$iy0TfVpV$YkL12Rk42daUGy40rvREt1",
-        "sshAuthorizedKeys": [
-          "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key"
-        ]
+        "sshAuthorizedKeys": ["BUILDERSSHAUTHKEY"]
       }
     ]
   },


### PR DESCRIPTION
To make the VMware guest VM get its persistent IP address via DHCP, we need to set `ClientIdenfier=mac` making use of systemd-networkd drop-in.

`ignition-builder.json` needs to have a pre-defined string `BUILDERSSHAUTHKEY`, which should be replaced with a user-specific ssh public key from the image-builder side.

_please do not merge, until we could be sure it is the correct approach for the DHCP issue in VMware._