### PR TITLE
Disable Flatcar updates

### DIFF
--- a/ignition-builder.json
+++ b/ignition-builder.json
@@ -34,24 +34,19 @@
       }
     ]
   },
-  "storage": {
-    "files": [
-      {
-        "filesystem": "root",
-        "path": "/etc/coreos/update.conf",
-        "contents": {
-          "source": "data:,%0AREBOOT_STRATEGY%3D%22reboot%22",
-          "verification": {}
-        },
-        "mode": 420
-      }
-    ]
-  },
   "systemd": {
     "units": [
       {
         "enable": true,
         "name": "docker.service"
+      },
+      {
+        "name": "update-engine.service",
+        "mask": true
+      },
+      {
+        "name": "locksmithd.service",
+        "mask": true
       }
     ]
   }


### PR DESCRIPTION
This Ignition config is used for *building* Flatcar images (as opposed to *running* Flatcar machines). Since the desired Flatcar version is typically specified when building the image, it makes no sense to reboot the machine during the image creation process (or even download an update) because doing so can break the image creation process as well as result in an image of an unexpected version.

Disabling update-engine and locksmithd fixes the issue. Removing the `/etc/coreos/update.conf` as it doesn't seem necessary.

See https://github.com/kubernetes-sigs/image-builder/issues/854.